### PR TITLE
Port to Spree 2.0 and add support for +4 address verification and tax calculation

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -71,7 +71,7 @@ Spree::Order.class_eval do
 
         cloud_rate = order.tax_cloud_transaction.amount / ( line_items_total + order.ship_total )
 
-        adjusted_total = line_items_total + order.promotions_total
+        adjusted_total = line_items_total + order.adjustment_total
 
         round_to_two_places( adjusted_total * cloud_rate )
 

--- a/app/models/spree/tax_cloud/tax_cloud_transaction.rb
+++ b/app/models/spree/tax_cloud/tax_cloud_transaction.rb
@@ -24,7 +24,7 @@ module Spree
 
 	 tax_rate =  amount / cart_price
 
-	 taxable = ( cart_price + order.promotions_total )
+	 taxable = ( cart_price + order.adjustment_total )
 	
 	 tax = round_to_two_places( taxable * tax_rate) 
 
@@ -109,7 +109,7 @@ module Spree
 
       def tax_cloud
 
-	 @tax_cloud ||= TaxCloud.new
+	 @tax_cloud ||= Tax_Cloud.new
 
       end
 

--- a/app/views/spree/admin/tax_cloud_settings/edit.html.erb
+++ b/app/views/spree/admin/tax_cloud_settings/edit.html.erb
@@ -9,7 +9,7 @@
       <fieldset>
         <legend><%= t('taxcloud_api_login_and_key') %></legend>
         <p>
-          <label><%= t('tax_cloud_api_login_id') %></label><br />
+          <label><%= t('taxcloud_api_login_id') %></label><br />
           <%= text_field_tag('settings[taxcloud_api_login_id]', Spree::Config.taxcloud_api_login_id, :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
         <p>
@@ -21,7 +21,7 @@
       <fieldset>
         <legend><%= t('taxcloud_taxability_codes') %></legend>
         <p>
-          <label><%= t('tax_cloud_product_taxability_code') %></label><br />
+          <label><%= t('taxcloud_product_taxability_code') %></label><br />
           <%= text_field_tag('settings[taxcloud_product_tic]', Spree::Config.taxcloud_product_tic, :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
         <p>
@@ -41,24 +41,28 @@
       <fieldset>
         <legend><%= t('business_address') %></legend>
         <p>
-          <label><%= t('address_1') %></label><br />
+          <label><%= Spree.t('address1') %></label><br />
 	  <%= text_field_tag('address[taxcloud_address1]', origin["Address1"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
         <p>
-          <label><%= t('address_2') %></label><br />
+          <label><%= Spree.t('address2') %></label><br />
 	  <%= text_field_tag('address[taxcloud_address2]', origin["Address2"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
         <p>
-          <label><%= t('city') %></label><br />
+          <label><%= Spree.t('city') %></label><br />
 	  <%= text_field_tag('address[taxcloud_city]', origin["City"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
         <p>
-          <label><%= t('state') %></label><br />
+          <label><%= Spree.t('state') %></label><br />
 	  <%= text_field_tag('address[taxcloud_state]', origin["State"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
         <p>
-          <label><%= t('zip5') %></label><br />
-	  <%= text_field_tag('address[taxcloud_zip5]', origin["Zip5"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
+          <label><%= Spree.t('zipcode') %></label><br />
+    <%= text_field_tag('address[taxcloud_zip5]', origin["Zip5"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
+        </p>
+        <p>
+          <label><%= t('zip_plus_4') %></label><br />
+    <%= text_field_tag('address[taxcloud_zip4]', origin["Zip4"], :size => 46, :maxlength => 256, :class => 'tax_cloud') %>
         </p>
 
       </fieldset>

--- a/app/views/spree/admin/tax_cloud_settings/show.html.erb
+++ b/app/views/spree/admin/tax_cloud_settings/show.html.erb
@@ -13,7 +13,7 @@
     <td><%= Spree::Config.taxcloud_api_key %></td>
   </tr>
   <tr>
-    <th scope="row"><%= t("tax_cloud_product_taxability_code") %>:</th>
+    <th scope="row"><%= t("taxcloud_product_taxability_code") %>:</th>
     <td><%= Spree::Config.taxcloud_product_tic %></td>
   </tr>
   <tr>
@@ -29,14 +29,15 @@
     <th scope="row"><%= t("business_address") %>:</th> 
 
     <td><table>
-<tr><td><%= t("address1") %>: <%= origin["address1"]  %> </td></tr>
-<tr><td><%= t("address2") %>: <%= origin["Address2"]  %></td></tr>
-<tr><td><%= t("city") %>: <%= origin["City"]  %></td></tr>
-<tr><td><%= t("state") %>: <%= origin["State"]  %></td></tr>
-<tr><td><%= t("zip_code") %>: <%= origin["Zip5"]  %></td></tr>
+<tr><td><%= Spree.t("address1") %>: <%= origin["Address1"]  %> </td></tr>
+<tr><td><%= Spree.t("address2") %>: <%= origin["Address2"]  %></td></tr>
+<tr><td><%= Spree.t("city") %>: <%= origin["City"]  %></td></tr>
+<tr><td><%= Spree.t("state") %>: <%= origin["State"]  %></td></tr>
+<tr><td><%= Spree.t("zipcode") %>: <%= origin["Zip5"]  %></td></tr>
+<tr><td><%= t("zip_plus_4") %>: <%= origin["Zip4"] %></td></tr>
 </table></td>
   </tr>    
 </table>
 
-<p><%= link_to_with_icon 'edit', t("edit"), edit_admin_tax_cloud_settings_path %></p>
+<p><%= link_to_with_icon 'edit', Spree.t("edit"), edit_admin_tax_cloud_settings_path %></p>
 

--- a/config/locales/en_spree.yml
+++ b/config/locales/en_spree.yml
@@ -1,3 +1,14 @@
 ---
 en:
-    
+    business_address: Business Address
+    save_preferences: Save Preferences
+    taxcloud_taxability_codes: TaxCloud Taxability Codes
+    taxcloud_settings: TaxCloud Settings
+    taxcloud_api_login_and_key: TaxCloud API Login and Key
+    taxcloud_api_login_id: TaxCloud API Login ID
+    taxcloud_api_key: TaxCloud API Key
+    taxcloud_product_taxability_code: TaxCloud Product Taxability Code
+    taxcloud_shipping_taxability_code: TaxCloud Shipping Taxability Code
+    usps_user: USPS User ID
+    usps_user_id: USPS API User ID
+    zip_plus_4: Zip +4

--- a/lib/spree_tax_cloud.rb
+++ b/lib/spree_tax_cloud.rb
@@ -1,3 +1,4 @@
 require 'spree_core'
 require 'spree_tax_cloud/engine'
+require 'tax_cloud'
 

--- a/spree_tax_cloud.gemspec
+++ b/spree_tax_cloud.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.add_dependency('spree_core', '> 1.3.1')
   s.add_runtime_dependency 'savon', '1.2.0'
+  s.add_runtime_dependency 'tax_cloud', '0.2.2'
 
 end


### PR DESCRIPTION
Add support for address validation and lookup of +4 zip. This allows more accurate tax
calculation for jurisdictions that use +4 regions to deliniate tax requirements.

Begin using gem 'tax_cloud' for some of these calculations like verify_address.
