### PR TITLE
Remove unused usps_user_id key

### DIFF
--- a/app/models/spree/tax_cloud.rb
+++ b/app/models/spree/tax_cloud.rb
@@ -78,9 +78,7 @@ module Spree
 
             {
                 'apiLoginID' => Spree::Config.taxcloud_api_login_id ,
-                'apiKey' => Spree::Config.taxcloud_api_key,
-		'uspsUserID' => Spree::Config.taxcloud_usps_user_id 
-
+                'apiKey' => Spree::Config.taxcloud_api_key
             }
 
         end


### PR DESCRIPTION
This configuration option is not needed in the 1-3-stable version and prevents spree_tax_cloud from working properly.
