### PR TITLE
Fixes to Spree::TaxCloud#destination_address

### DIFF
--- a/app/models/spree/tax_cloud.rb
+++ b/app/models/spree/tax_cloud.rb
@@ -81,27 +81,18 @@ module Spree
         end
 
         def destination_address(address)
-          address_hash = {
-            'Address1' => address.address1,
-            'Address2' => address.address2,
-            'City'     => address.city,
-            'State'    => address.state.abbr,
-            'Zip5'     => address.zipcode[0..4]
-          }
+          address = ::TaxCloud::Address.new({
+            :address1 => address.address1,
+            :address2 => address.address2,
+            :city     => address.city,
+            :state    => address.state.abbr,
+            :zip5     => address.zipcode[0..4]
+          })
           # Only attempt to verify address if user has configured their USPS account.
-          if Spree::Config.taxcloud_usps_user_id
-            tax_cloud_address = TaxCloud::Address.new address_hash
-            verified_address  = tax_cloud_address.verify
-            address_hash = {
-              'Address1' => verified_address.address1,
-              'Address2' => verified_address.address2,
-              'City'     => verified_address.city,
-              'State'    => verified_address.state,
-              'Zip5'     => verified_address.zip5,
-              'Zip4'     => verified_address.zip4
-            }
+          if Spree::Config.taxcloud_usps_user_id.present?
+            address = address.verify
           end
-          address_hash
+          address.to_hash
         end
 
         def origin_address


### PR DESCRIPTION
I ran into a couple issues running spree_tax_cloud on ruby 2.0.0 and spree 2.0.3.

TaxCloud::Address was attempting to refer to Spree::TaxCloud::Address, which caused an error. Replaced with explicit ::TaxCloud::Address

taxcloud_usps_user_id was an empty string after saving the configuration. Updated the test to check that it is .present?

TaxCloud::Address was then initialized using Capitalized strings, which the tax_cloud gem doesn't seem to take
https://github.com/drewtempelmeyer/tax_cloud
