### PR TITLE
Add useful error hooks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,13 +29,28 @@ login, api_id, product tic, shipping tic, and business address.
 
 
 
-===Handle exceptions
-There are several exceptions that SpreeTaxCloud can throw. You may want to use
-the rescue_from method (http://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from)
-in your Spree checkout controller to handle the following exceptions:
+===Exceptions
+Handling exceptions during Spree's checkout state machine is an important
+part of integrating Tax Cloud. There are two broad cases which spree_tax_cloud handles:
 
-- TaxCloudAPILoginMissing
-- TaxCloudAPIKeyMissing
+====A HTTP response != 200
+If for any reason a connection cannot be made to Tax Cloud, or the API's HTTP response code is
+something other than 200, this error is silently ignored, allowing checkout to proceed without
+a tax calculation. You can change this default by overriding Spree::Order#handle_unknown_lookup_error
+and Spree::Order#handle_unknown_capture_error.
+
+
+====A HTTP response == 200, 
+If communication is functioning properly with the API, but the submitted data, causes
+the API to return an error code during lookup or capture, the error is silently ignored, 
+allowing checkout to proceed without a tax calculation. You can change this default by 
+overriding Spree::Order#rescue_tax_cloud_lookup_error and Spree::Order#rescue_tax_cloud_capture_error.
+
+
+====Exception Notification
+It's probably a good idea to override the default methods anyway to be able to add exception notifications, so you can monitor
+the rate at which TaxCloud related exceptions are occuring.
+
 
 ===NOTE
 

--- a/app/models/spree/tax_cloud.rb
+++ b/app/models/spree/tax_cloud.rb
@@ -2,26 +2,20 @@
 
 require 'savon'
 require 'spree/tax_cloud/savon_xml_override'
+require 'spree/tax_cloud/tax_cloud_exceptions'
 
 module Spree
-
-
-  class TaxCloudAPILoginMissing < Exception
-    # Used when the API login ID is not specified as a Spree preference
-  end
-
-
-  class TaxCloudAPIKeyMissing < Exception
-    # Used when the API key is not specified as a Spree preference
-  end
-
 
   class TaxCloud
 
     def lookup(tax_cloud_transaction)
-      client.request(:lookup) do
+      response = client.request(:lookup) do
         soap.body = lookup_params(tax_cloud_transaction)
       end
+
+      raise Spree::TaxCloudLookupError.new(response) if response.present? and response.body.dig(:lookup_response, :lookup_result, :response_type) ==  "Error"
+
+      response
     end
 
 
@@ -38,7 +32,7 @@ module Spree
 
     def capture(tax_cloud_transaction)
       order = tax_cloud_transaction.order
-      client.request(:authorized_with_capture) do
+      response = client.request(:authorized_with_capture) do
         soap.body = default_body.merge({ 'customerID' => order.user_id,
                                          'cartID' => order.number,
                                          'orderID' => order.number,
@@ -46,6 +40,10 @@ module Spree
                                          'dateCaptured' => DateTime.now
                                        })
       end
+
+      raise Spree::TaxCloudCaptureError.new(response) if response.present? and response.body.dig(:lookup_response, :lookup_result, :response_type) ==  "Error"
+
+      response
     end
 
 
@@ -61,12 +59,15 @@ module Spree
 
     def client
       @client ||= Savon::Client.new("https://api.taxcloud.net/1.0/?wsdl")
+      @client.config.logger = Rails.logger
+      @client
     end
 
 
     def default_body
-      raise Spree::TaxCloudAPILoginMissing if Spree::Config.taxcloud_api_login_id.blank?$
-      raise Spree::TaxCloudAPIKeyMissing   if Spree::Config.taxcloud_api_key.blank?
+      raise TaxCloudAPILoginMissing.new if Spree::Config.taxcloud_api_login_id.blank?
+      raise TaxCloudAPIKeyMissing.new   if Spree::Config.taxcloud_api_key.blank?
+
       {
         'apiLoginID' => Spree::Config.taxcloud_api_login_id,
         'apiKey' => Spree::Config.taxcloud_api_key

--- a/app/models/spree/tax_cloud/tax_cloud_exceptions.rb
+++ b/app/models/spree/tax_cloud/tax_cloud_exceptions.rb
@@ -1,0 +1,35 @@
+module Spree
+
+  class TaxCloudResponseError < StandardError
+    attr_reader :response, :response_message
+    def initialize(response)
+      @response = response
+      if @response.present? and @response.body.present?
+        @response_message  = @response.body.dig(:lookup_response, :lookup_result, :messages, :response_message, :message)
+      else
+        @response_message  = "An unknown error occured."
+      end
+    end
+  end
+
+
+  class TaxCloudLookupError < TaxCloudResponseError
+    # Used when the response is a 200, but the API returns an error code
+  end
+
+
+  class TaxCloudCaptureError < TaxCloudResponseError
+    # Used when the response is a 200, but the API returns an error code
+  end
+
+
+  class TaxCloudAPILoginMissing < StandardError
+    # Used when the API login ID is not specified as a Spree preference
+  end
+
+
+  class TaxCloudAPIKeyMissing < StandardError
+    # Used when the API key is not specified as a Spree preference
+  end
+
+end

--- a/config/initializers/safe_hash_lookup.rb
+++ b/config/initializers/safe_hash_lookup.rb
@@ -1,0 +1,16 @@
+class Hash
+
+  unless Hash.method_defined?(:dig)
+
+
+    # Used to safely look up deeply nested hash values
+    # Usage: response.body.dig(:lookup_response, :lookup_result, :messages, :response_message, :message)
+    def dig(*path)
+      path.inject(self) do |location, key|
+        location.respond_to?(:keys) ? location[key] : nil
+      end
+    end
+
+
+  end
+end


### PR DESCRIPTION
@bluehandtalking

Sorry for the splash of pull requests. I'm trying to give you options about how much you want to pull in. All the previous ones build up to this BIG one. Let me give you some backstory.

Essentially, this PR started for one simple reason...currently the 1-3-stable branch will return an unhandled exception if the user provides Tax Cloud with a zip code which does not match the provided state. This is obviously, not so good.

This pull request (and centrally f8a8f01) is about two things:
- Provide a sane default behavior when errors occur: don't do a tax calculation and allow the checkout to complete.
- Give developers hooks to be able to interact with the API's errors and handle them as desired.

I am using the hooks provided by f8a8f01 (as documented in the README) in order to give users an opportunity to correct their addresses. Let me know if you want more information or more explicit documentation in the README. I'm kinda burnt on this, as it's taken a lot of work, but I think it's a big improvement on an important branch.....I hear Spree 2.0 is pretty unstable now, and I'm steering clients away from it.

Thanks for your previous work to build on!
