### PR TITLE
Avoid setting nil amount if tax calculation is NaN.

### DIFF
--- a/app/models/spree/tax_cloud_transaction.rb
+++ b/app/models/spree/tax_cloud_transaction.rb
@@ -18,7 +18,7 @@ module Spree
     def update_adjustment(adjustment, source)
       rate = amount / order.item_total
       tax = (order.item_total - order.promotions_total) * rate
-      adjustment.update_attribute_without_callbacks(:amount, tax)
+      adjustment.update_attribute_without_callbacks(:amount, tax) unless tax.nan?
     end
 
     def lookup


### PR DESCRIPTION
Not sure that this is the correct solution, but it does solve the problem of nil adjustments getting created in Spree.

This problem was first discovered when removing the last item from the cart using the 'X' delete. Feels like this is an indication of some other problem upstream.

This addresses issue reported on spree/spree: https://github.com/spree/spree/issues/3348
