### PR TITLE
Fix precision, scale of decimal columns on cart_item

### DIFF
--- a/db/migrate/20130829215819_fix_scale_of_cart_item_prices.rb
+++ b/db/migrate/20130829215819_fix_scale_of_cart_item_prices.rb
@@ -1,0 +1,13 @@
+class FixScaleOfCartItemPrices < ActiveRecord::Migration
+  def up
+    change_column :spree_tax_cloud_cart_items, :price,      :decimal, :precision => 8,  :scale => 2
+    change_column :spree_tax_cloud_cart_items, :ship_total, :decimal, :precision => 10, :scale => 2
+    change_column :spree_tax_cloud_cart_items, :amount,     :decimal, :precision => 13, :scale => 5
+  end
+
+  def down
+    change_column :spree_tax_cloud_cart_items, :price,      :decimal, :precision => 8, :scale => 5
+    change_column :spree_tax_cloud_cart_items, :ship_total, :decimal, :precision => 8, :scale => 5
+    change_column :spree_tax_cloud_cart_items, :amount,     :decimal, :precision => 8, :scale => 5
+  end
+end


### PR DESCRIPTION
The columns were originally created with precision=8 scale=5, which does not allow prices greater than 999.

This changes:
- `price` to the same as line_item.price (precision=8 scale=2)
- `ship_total` to the same as adjustment.amount (precision=10 scale=2)
- `amount` to precision=13 scale=5, which can fit the maximum allowable amount of either column at 5 decimal places of precision.
