### PR TITLE
Addressing warning msg by adding :original for add_tax_cloud_admin_menu

### DIFF
--- a/app/overrides/add_tax_cloud_admin_menu_link.rb
+++ b/app/overrides/add_tax_cloud_admin_menu_link.rb
@@ -3,5 +3,6 @@ Deface::Override.new(:virtual_path  => 'spree/admin/shared/_configuration_menu',
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
                      :text => %q{
                         <%= configurations_sidebar_menu_item 'Taxcloud Settings', admin_tax_cloud_settings_path%>
-                     })
+                     },
+                     :original => '8e7dd42cfde1795276b04835e0c2b9948a7cadaf')
 


### PR DESCRIPTION
Addressing issue:

```
No :original defined for 'add_tax_cloud_admin_menu_link', you should change its definition to include:
 :original => '8e7dd42cfde1795276b04835e0c2b9948a7cadaf'
```
