### PR TITLE
Preventing nil tax_cloud_transcation.adjustment from crashing lookup

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -35,7 +35,7 @@ Spree::Order.class_eval do
         tax_cloud_transaction.cart_items.destroy
         tax_cloud_transaction.lookup
 
-        tax_cloud_transaction.adjustment.destroy
+        tax_cloud_transaction.adjustment.destroy if tax_cloud_transaction.adjustment
         tax_cloud_adjustment
 
       else


### PR DESCRIPTION
I was getting exceptions from line 38 here, `tax_cloud_transaction.adjustment.destroy`, as Rails was saying that `tax_cloud_transaction.adjustment` was `nil`. (And `nil` doesn't have a `destroy` method.)

It seems like if the idea is to destroy the `tax_cloud_transaction.adjustment` anyway, then it's a simple fix to make the line contingent on there being such an object to destroy.

If the lack of a `tax_cloud_transaction.adjustment` is such a big problem that we _want_ to fail here, then I'm curious to understand more deeply how the logic works and how to troubleshoot my particular application, but the proposed change would seem to be the simplest and most direct way of addressing it, as far as I can see.
