### PR TITLE
Strip whitespace from Spree zipcode field

### DIFF
--- a/app/models/spree/tax_cloud_transaction.rb
+++ b/app/models/spree/tax_cloud_transaction.rb
@@ -34,7 +34,7 @@ module Spree
       address2:   address.address2,
       city:       address.city,
       state:      address.try(:state).try(:abbr), # replace with state_text if possible
-      zip5:       address.zipcode[0...5]
+      zip5:       address.zipcode.try(:strip).try(:[], 0...5)
       )
     end
     def self.cart_item_from_item(item, index)


### PR DESCRIPTION
Spree allows anything to be saved in the zipcode field (with little validation), since it has to accept any kind of worldwide zip codes.

That allows users to put heading (or trailing) whitespace in there (very frequent when autofilling or copy/pasting addresses), breaking TaxCloud integration when trying to get the first 5 digits. Striping whitespace right before sending it to TaxCloud solves the issue, without altering whatever's saved in Spree models.
